### PR TITLE
Update scapy

### DIFF
--- a/py3-requirements.txt
+++ b/py3-requirements.txt
@@ -1,2 +1,2 @@
-scapy-python3
+scapy>=2.4.0
 -r common-requirements.txt


### PR DESCRIPTION
scapy-python3 is an unofficial fork that is getting very oudated (many bug fixes missing).
Migrates to original and up-to-date scapy, which now supports both python 2 and 3