### PR TITLE
Added support for long-lived Home Assistant access tokens

### DIFF
--- a/amazon_dash/execute.py
+++ b/amazon_dash/execute.py
@@ -341,9 +341,13 @@ class ExecuteHomeAssistant(ExecuteOwnApiBase):
         return url
 
     def get_headers(self):
-        return {
-            'x-ha-access': self.data['access']
-        } if 'access' in self.data else {}
+        headers = {}
+        if 'access_token' in self.data:
+            headers['Authorization'] = 'Bearer {0}'.format(self.data['access_token'])
+        elif 'access' in self.data:
+            headers['x-ha-access'] = self.data['access']
+
+        return headers
 
 
 class ExecuteOpenHab(ExecuteOwnApiBase):

--- a/amazon_dash/tests/test_execute.py
+++ b/amazon_dash/tests/test_execute.py
@@ -300,7 +300,7 @@ class TestExecuteHomeAssistant(unittest.TestCase):
     def test_execute_with_access_token(self):
         with requests_mock.mock() as m:
             m.post(self.url, text='success', request_headers={'Authorization': 'Bearer abcde12345'})
-            assis = ExecuteHomeAssistant('key', self.default_data(extra_data={'Authorization': 'Bearer abcde12345'}))
+            assis = ExecuteHomeAssistant('key', self.default_data(extra_data={'access_token': 'abcde12345'}))
             assis.execute()
             self.assertTrue(m.called_once)
 

--- a/amazon_dash/tests/test_execute.py
+++ b/amazon_dash/tests/test_execute.py
@@ -132,7 +132,7 @@ class TestExecuteCmd(ExecuteMockBase, unittest.TestCase):
 class TestExecuteUrl(unittest.TestCase):
     no_body_methods = ['get', 'head', 'delete', 'connect', 'options', 'trace']
     url = 'http://domain.com'
-    
+
     def setUp(self):
         super(TestExecuteUrl, self).setUp()
         self.session_mock = requests_mock.Mocker()
@@ -294,6 +294,13 @@ class TestExecuteHomeAssistant(unittest.TestCase):
         with requests_mock.mock() as m:
             m.post(self.url, text='success', request_headers={'x-ha-access': 'password'})
             assis = ExecuteHomeAssistant('key', self.default_data(extra_data={'access': 'password'}))
+            assis.execute()
+            self.assertTrue(m.called_once)
+
+    def test_execute_with_access_token(self):
+        with requests_mock.mock() as m:
+            m.post(self.url, text='success', request_headers={'Authorization': 'Bearer abcde12345'})
+            assis = ExecuteHomeAssistant('key', self.default_data(extra_data={'Authorization': 'Bearer abcde12345'}))
             assis.execute()
             self.assertTrue(m.called_once)
 

--- a/docs/config_file.rst
+++ b/docs/config_file.rst
@@ -98,7 +98,7 @@ for each device. The available exection methods are:
 
 * **cmd**: local command line command. Arguments can be placed after the command.
 * **url**: Call a url.
-* **homeassistant**: send event to Homeassistant. This argument must be the address to the hass server (protocol and
+* **homeassistant**: send event to Home Assistant. This argument must be the address to the hass server (protocol and
   port are optional. By default http and 8123, respectively).
 * **openhab**: send event to OpenHAB. This argument must be the address to the hass server (protocol and
   port are optional. By default http and 8080, respectively).
@@ -248,13 +248,21 @@ Example:
         confirmation: send-tg
 
 
-Homeassistant event
+Home Assistant event
 ~~~~~~~~~~~~~~~~~~~
 When the **homeassistant execution method** is used, the following options are available.
 
 * **event** (required): Event name to send.
 * **data**: Event data to send. Use json as string.
-* **access**: HomeAssistant password for API (``x-ha-access`` header).
+* **access_token**: Long-lived Home Assistant access token.
+* **access**: Home Assistant legacy API password (``x-ha-access`` header).
+
+Starting with version 0.78 of Home Assistant, there are two ways Amazon Dash can authenticate:
+
+1. By providing a long-lived access token (generated within your Home Assistant profile page) via the ``access_token`` option.
+2. By providing the legacy Home Assistant API password via the ``access`` option.
+
+Although both options currently work, the Home Assistant project plans to deprecate (and likely remove) the legacy API password in the future; therefore, to properly future proof your Amazon Dash setup, the long-lived access token option is recommended.
 
 The protocol and the port in the address of the Homeassistant server are optional. The syntax of the address is:
 ``[<protocol>://]<server>[:<port>]. For example: ``https://hassio.local:1234``.


### PR DESCRIPTION
This PR adds support for [long-lived Home Assistant access tokens](https://developers.home-assistant.io/docs/en/auth_api.html#long-lived-access-token) (which is the Home Assistant-promoted method for external API access going forward). To keep backward compatibility, the `access` option is still supported (although at some point, Home Assistant will deprecate and remove that option, at which point it should be removed here, too.

Addresses https://github.com/Nekmo/amazon-dash/issues/81.