### PR TITLE
Added a User Agent in Headers

### DIFF
--- a/amazon_dash/execute.py
+++ b/amazon_dash/execute.py
@@ -213,6 +213,7 @@ class ExecuteUrl(Execute):
         if self.data.get('auth'):
             kwargs['auth'] = tuple(self.data['auth'].split(':', 1))
         try:
+            kwargs['headers']['user-agent'] ='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'
             resp = request(self.data.get('method', 'get').lower(), self.data['url'],
                            verify=self.data.get('verify', True),
                            **kwargs)


### PR DESCRIPTION
The request fails (403) in some sites that requires User Agents.
Sites like https://www.virtualsmarthome.xyz requires a User Agent.
Since this site is widely used to call Alexa routines via URL, adding a User Agent on the request() seems prudent.